### PR TITLE
fix texture starting point

### DIFF
--- a/render_screen.c
+++ b/render_screen.c
@@ -5,36 +5,31 @@ void draw_image_column(t_game *game, t_ray ray, int column)
 	int ground_color = 0x5e3306;
 	int sky_color = 0x06c5cf;
 	double column_height;
-	double offset; // column height
+	double offset; // difference between the column height and the screen height
 
-	printf("ray.size: %f\n", ray.size);
-	printf("Column height: %f\n", column_height);
-	column_height = (1 / ray.size) * 1500;
+	column_height = (HEIGHT / ray.size) * 5;
 	offset = ceil((HEIGHT - column_height) / 2);
 	int y = 1;
 	while (y < offset) // THIS DRAWS THE GROUND
 	{
-		int pixel = (y * game->columns.line_size) + (column * 4); // change the 'offset' to top offset the dist
-
-		game->columns.pixels[pixel + 0] = (ground_color);	// blue
-		game->columns.pixels[pixel + 1] = (ground_color >> 8);	// green
-		game->columns.pixels[pixel + 2] = (ground_color >> 16);	// red
-		game->columns.pixels[pixel + 3] = 0;	// alpha
+		int pixel = (y * game->columns.line_size) + (column * 4);	// change the 'offset' to top offset the dist
+		game->columns.pixels[pixel + 0] = (ground_color);			// blue
+		game->columns.pixels[pixel + 1] = (ground_color >> 8);		// green
+		game->columns.pixels[pixel + 2] = (ground_color >> 16);		// red
+		game->columns.pixels[pixel + 3] = 0;						// alpha
 		y++;
 	}
 	double texture_y;
+	double step_y = (ray.texture.size.y / column_height);
 	if (column_height < HEIGHT)
 		texture_y = 0;
 	else // start with an offset
-		texture_y = column_height;
-	printf("texture_y: %f\n", texture_y);
-	double step_y = (256 / column_height);
+		texture_y = (((ray.texture.size.y / step_y) - HEIGHT) / 2) * step_y;
 	while (y < HEIGHT - offset) // THIS DRAWS THE COLUMNS
 	{
 		int pixel = (y * game->columns.line_size) + (column * 4); // change the 'offset' to top offset the dist
 		int texture_offset_x = (column % 256) * 4;
 		int current_texture_y = (int)floor(texture_y);
-
 		game->columns.pixels[pixel + 0] = ray.texture.pixels[(current_texture_y * ray.texture.line_size + texture_offset_x) + 0];	// blue
 		game->columns.pixels[pixel + 1] = ray.texture.pixels[(current_texture_y * ray.texture.line_size + texture_offset_x) + 1];	// green
 		game->columns.pixels[pixel + 2] = ray.texture.pixels[(current_texture_y * ray.texture.line_size + texture_offset_x) + 2];	// red
@@ -44,12 +39,11 @@ void draw_image_column(t_game *game, t_ray ray, int column)
 	}
 	while (y < HEIGHT) // THIS DRAWS THE SKY
 	{
-		int pixel = (y * game->columns.line_size) + (column * 4); // change the 'offset' to top offset the dist
-
-		game->columns.pixels[pixel + 0] = (sky_color);		// blue
-		game->columns.pixels[pixel + 1] = (sky_color >> 8);	// green
-		game->columns.pixels[pixel + 2] = (sky_color >> 16);	// red
-		game->columns.pixels[pixel + 3] = 0;	// alpha
+		int pixel = (y * game->columns.line_size) + (column * 4);	// change the 'offset' to top offset the dist
+		game->columns.pixels[pixel + 0] = (sky_color);				// blue
+		game->columns.pixels[pixel + 1] = (sky_color >> 8);			// green
+		game->columns.pixels[pixel + 2] = (sky_color >> 16);		// red
+		game->columns.pixels[pixel + 3] = 0;						// alpha
 		y++;
 	}
 	return;


### PR DESCRIPTION
Fix texture starting point when the column projected is bigger than the size of the the screen (right side of the image below)
![image](https://user-images.githubusercontent.com/26127185/208618656-29076e4e-0a77-4424-89c9-9f32e1f493c7.png)
